### PR TITLE
Add VisaService model, serializer, viewset, and tests

### DIFF
--- a/apps/backend/accounts/models.py
+++ b/apps/backend/accounts/models.py
@@ -43,3 +43,14 @@ class User(AbstractBaseUser, PermissionsMixin):
 
     def __str__(self):
         return self.username
+
+class VisaService(models.Model):
+    title = models.CharField(max_length=255)
+    description = models.TextField()
+    requirements = models.TextField()
+    processing_time = models.IntegerField()
+    price = models.DecimalField(max_digits=10, decimal_places=2)
+    is_featured = models.BooleanField(default=False)
+
+    def __str__(self):
+        return self.title

--- a/apps/backend/accounts/serializers.py
+++ b/apps/backend/accounts/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import VisaService
+
+class VisaServiceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = VisaService
+        fields = ['id', 'title', 'description', 'requirements', 'processing_time', 'price', 'is_featured']

--- a/apps/backend/accounts/tests.py
+++ b/apps/backend/accounts/tests.py
@@ -1,0 +1,111 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework import status
+from .models import VisaService
+from .serializers import VisaServiceSerializer
+
+class VisaServiceModelTest(TestCase):
+    def setUp(self):
+        self.visa_service = VisaService.objects.create(
+            title="Test Visa Service",
+            description="Test Description",
+            requirements="Test Requirements",
+            processing_time=10,
+            price=100.00,
+            is_featured=True
+        )
+
+    def test_visa_service_creation(self):
+        self.assertEqual(self.visa_service.title, "Test Visa Service")
+        self.assertEqual(self.visa_service.description, "Test Description")
+        self.assertEqual(self.visa_service.requirements, "Test Requirements")
+        self.assertEqual(self.visa_service.processing_time, 10)
+        self.assertEqual(self.visa_service.price, 100.00)
+        self.assertTrue(self.visa_service.is_featured)
+
+class VisaServiceSerializerTest(TestCase):
+    def setUp(self):
+        self.visa_service_attributes = {
+            'title': 'Test Visa Service',
+            'description': 'Test Description',
+            'requirements': 'Test Requirements',
+            'processing_time': 10,
+            'price': 100.00,
+            'is_featured': True
+        }
+
+        self.serializer_data = {
+            'title': 'Test Visa Service',
+            'description': 'Test Description',
+            'requirements': 'Test Requirements',
+            'processing_time': 10,
+            'price': 100.00,
+            'is_featured': True
+        }
+
+        self.visa_service = VisaService.objects.create(**self.visa_service_attributes)
+        self.serializer = VisaServiceSerializer(instance=self.visa_service)
+
+    def test_contains_expected_fields(self):
+        data = self.serializer.data
+        self.assertEqual(set(data.keys()), set(['id', 'title', 'description', 'requirements', 'processing_time', 'price', 'is_featured']))
+
+    def test_title_field_content(self):
+        data = self.serializer.data
+        self.assertEqual(data['title'], self.visa_service_attributes['title'])
+
+    def test_description_field_content(self):
+        data = self.serializer.data
+        self.assertEqual(data['description'], self.visa_service_attributes['description'])
+
+    def test_requirements_field_content(self):
+        data = self.serializer.data
+        self.assertEqual(data['requirements'], self.visa_service_attributes['requirements'])
+
+    def test_processing_time_field_content(self):
+        data = self.serializer.data
+        self.assertEqual(data['processing_time'], self.visa_service_attributes['processing_time'])
+
+    def test_price_field_content(self):
+        data = self.serializer.data
+        self.assertEqual(data['price'], self.visa_service_attributes['price'])
+
+    def test_is_featured_field_content(self):
+        data = self.serializer.data
+        self.assertEqual(data['is_featured'], self.visa_service_attributes['is_featured'])
+
+class VisaServiceViewSetTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.visa_service_data = {
+            'title': 'Test Visa Service',
+            'description': 'Test Description',
+            'requirements': 'Test Requirements',
+            'processing_time': 10,
+            'price': 100.00,
+            'is_featured': True
+        }
+        self.visa_service = VisaService.objects.create(**self.visa_service_data)
+        self.url = f'/visa-services/{self.visa_service.id}/'
+
+    def test_get_visa_service(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['title'], self.visa_service_data['title'])
+
+    def test_create_visa_service(self):
+        response = self.client.post('/visa-services/', self.visa_service_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['title'], self.visa_service_data['title'])
+
+    def test_update_visa_service(self):
+        updated_data = self.visa_service_data.copy()
+        updated_data['title'] = 'Updated Test Visa Service'
+        response = self.client.put(self.url, updated_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['title'], updated_data['title'])
+
+    def test_delete_visa_service(self):
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(VisaService.objects.filter(id=self.visa_service.id).exists())

--- a/apps/backend/accounts/urls.py
+++ b/apps/backend/accounts/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from .views import VisaServiceViewSet
+
+router = DefaultRouter()
+router.register(r'visa-services', VisaServiceViewSet)
+
+urlpatterns = [
+    path('', include(router.urls)),
+]

--- a/apps/backend/accounts/views.py
+++ b/apps/backend/accounts/views.py
@@ -1,0 +1,7 @@
+from rest_framework import viewsets
+from .models import VisaService
+from .serializers import VisaServiceSerializer
+
+class VisaServiceViewSet(viewsets.ModelViewSet):
+    queryset = VisaService.objects.all()
+    serializer_class = VisaServiceSerializer


### PR DESCRIPTION
Add VisaService model, serializer, viewset, URL routes, and tests.

* **Model**: Add `VisaService` model with fields: `title`, `description`, `requirements`, `processing_time`, `price`, `is_featured` in `apps/backend/accounts/models.py`.
* **Serializer**: Add `VisaServiceSerializer` for `VisaService` model in `apps/backend/accounts/serializers.py`.
* **Viewset**: Add `VisaServiceViewSet` for CRUD operations on `VisaService` model in `apps/backend/accounts/views.py`.
* **URLs**: Add URL routes for `VisaServiceViewSet` in `apps/backend/accounts/urls.py`.
* **Tests**: Add tests for `VisaService` model, serializer, and viewset in `apps/backend/accounts/tests.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sisovin/modern-visa-immigration/pull/8?shareId=e65fb5b9-df88-4305-b4d1-d7af212c7da2).